### PR TITLE
Implement free text query

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ Modifed to use single query that gets the maximium of both In & Out throughput:
 ```
 LINK NODE1-NODE2
     NODES NODE1 NODE2
-    TARGET max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]) or irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8
+    TARGET prometheus:http:localhost:9090:max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]) or irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8
 ```
-These free-text PromQL queries can be very powerful.
+These free-text PromQL queries can be very powerful. However, they can be slow and expensive for your prometheus server to answer if they are too complex. So care should be taken when writing them so as not to overload your prometheus server.
 
 
 ## Generate your graph

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ you have a x8 multiplier at the end.
 Target needs:
 - **datasource:** prometheus
 - **proto:** http|https
-- **remote_host:** address of the prometheus database. ( only tested with IP )
-- **remote_port:** port on which the prometheus database listen to.
-- **instance:** the SNMP target you looking data to. ( only tested with IP )
-- **intf_name:** the interface on that target specifically. ( only tested with ciscoishh intf name )
+- **remote_host:** address of the prometheus database.
+- **remote_port:** port on which the prometheus database listens.
+- **instance:** the SNMP target that you want the data for.
+- **intf_name:** the interface on that target specifically. ( only tested with cisco/juniperish intf name )
 - **series_in/series_out:** the series to look into. ( only tested with ifHCInOctets/ifHCOutOctets )
 
 Something like this for dual series
@@ -92,6 +92,22 @@ Something like this for dual series
 
 and with a single series:
 - `prometheus:proto:remote_host:remote_port:instance:intf_name:series_in`
+
+#### Free-text Queries:
+The datasource has been extended to allow free-text PromQL queries to Prometheus. This allows the use of any metric (not just network interfaces) and complex queries.
+
+This alternative target needs:
+- **datasource:** prometheus
+- **proto:** http|https
+- **remote_host:** address of the prometheus database.
+- **remote_port:** port on which the prometheus database listens.
+- **query_in/query_out:** the PromQL query to pass to Prometheus.
+
+Soething like this for a dual query:
+- `prometheus:proto:remote_host:remote_port:free_text_query_in:free_text_query_out`
+
+and with a single series:
+- `prometheus:proto:remote_host:remote_port:free_text_query_in`
 
 
 ## Adding the datasource to weathermap
@@ -118,6 +134,24 @@ LINK NODE1-NODE2
     NODES NODE1 NODE2
     TARGET prometheus:http:localhost:9090:192.168.178.32:Gi0/1:ifHCInOctets
 ```
+
+This example uases a free-text query to get the throughput of the busiest link in a LAG as a dual query, getting both In and Out:
+```
+LINK NODE1-NODE2
+    NODES NODE1 NODE2
+    TARGET prometheus:http:localhost:9090:max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:max(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8
+```
+In this case we're identifying the interfaces that make up this LAG using a regex query on the ifAlias label.
+
+Modifed to use single query that gets the maximium of both In & Out throughput:
+```
+LINK NODE1-NODE2
+    NODES NODE1 NODE2
+    TARGET max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]) or irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8
+```
+These free-text PromQL queries can be very powerful.
+
+
 ## Generate your graph
 Use wmap like you would normally do, graphs should generate just fine.
 Here the only errors shown are normal given my setup, i don't need `snmp` or `rrd` modules from PHP.
@@ -193,7 +227,7 @@ I didn't make it on my very own, found the inspiration with those existing docs 
 
 ## Last words ?
 
-Fell free to test, report, patch, enjoy or hate it.
+Feel free to test, report, patch, enjoy or hate it.
 
 Cheers,
 Lodpp

--- a/WeatherMapDataSource_prometheus.php
+++ b/WeatherMapDataSource_prometheus.php
@@ -30,8 +30,8 @@
 // - TARGET prometheus:http:localhost:9090:192.168.178.32:Gi0/1:ifHCInOctets
 
 
-// Extended to allow free-text Prometheus queries. This allows polling any Prometheus metric or
-// use complex quueries.
+// Extended to allow free-text Prometheus queries. This allows polling any Prometheus metric and
+// use of complex queries in targets.
 
 // In this case TARGET will look like:
 // prometheus:proto:remote_host:remote_port:free_text_query_in:free_text_query_out

--- a/WeatherMapDataSource_prometheus.php
+++ b/WeatherMapDataSource_prometheus.php
@@ -39,7 +39,7 @@
 // prometheus:proto:remote_host:remote_port:free_text_query_in
 
 // This exmple shows how powerful this can be. It uses the max() with regex matching to poll the busiest 
-// link in a bundle on a given routyer, identified here by having 'ae232' in the interface descriotion 
+// link in a bundle on a given router, identified here by having 'ae232' in the interface description 
 // (which in this case show up as ifAlias).
 // - TARGET prometheus:http:localhost:9090:max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:max(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8
 
@@ -123,8 +123,8 @@ class WeatherMapDataSource_prometheus extends WeatherMapDataSource {
     
             $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
     
-            $in_query  = 'irate(' . $in_series  . '{ifName="' . $intf . '",instance="' . $instance . '"}[10m])*8';
-            $out_query = 'irate(' . $out_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[10m])*8';
+            $in_query  = 'irate(' . $in_series  . '{ifName="' . $intf . '",instance="' . $instance . '"}[2m])*8';
+            $out_query = 'irate(' . $out_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[2m])*8';
     
             // IN
             $query = urlencode($in_query);
@@ -148,7 +148,7 @@ class WeatherMapDataSource_prometheus extends WeatherMapDataSource {
     
             $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
     
-            $in_query = 'irate(' . $in_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[10m])*8';
+            $in_query = 'irate(' . $in_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[2m])*8';
     
             $query = urlencode($in_query);
             $call = $url . $query;

--- a/WeatherMapDataSource_prometheus.php
+++ b/WeatherMapDataSource_prometheus.php
@@ -29,11 +29,28 @@
 // or
 // - TARGET prometheus:http:localhost:9090:192.168.178.32:Gi0/1:ifHCInOctets
 
+
+// Extended to allow free-text Prometheus queries. This allows polling any Prometheus metric or
+// use complex quueries.
+
+// In this case TARGET will look like:
+// prometheus:proto:remote_host:remote_port:free_text_query_in:free_text_query_out
+// or
+// prometheus:proto:remote_host:remote_port:free_text_query_in
+
+// This exmple shows how powerful this can be. It uses the max() with regex matching to poll the busiest 
+// link in a bundle on a given routyer, identified here by having 'ae232' in the interface descriotion 
+// (which in this case show up as ifAlias).
+// - TARGET prometheus:http:localhost:9090:max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:max(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8
+
 class WeatherMapDataSource_prometheus extends WeatherMapDataSource {
 
     // FIXME: regexes probably too permissive.
     private $prom_regex_single_value = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([a-zA-z0-9-_.]+)\:([^:]+)\:([^:]+)$/';
     private $prom_regex_dual_value   = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([a-zA-z0-9-_.]+)\:([^:]+)\:([^:]+)\:([^:]+)$/';
+    private $prom_regex_single_query = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([^:]+)$/';
+    private $prom_regex_dual_query   = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([^:]+)\:([^:]+)$/';
+
 
     function Init(&$map)
     {
@@ -46,7 +63,9 @@ class WeatherMapDataSource_prometheus extends WeatherMapDataSource {
     {
 
         if( preg_match($this->prom_regex_single_value,$targetstring,$matches) ||
-            preg_match($this->prom_regex_dual_value,$targetstring,$matches) )
+            preg_match($this->prom_regex_dual_value,$targetstring,$matches) ||
+            preg_match($this->prom_regex_single_query,$targetstring,$matches) ||
+            preg_match($this->prom_regex_dual_query,$targetstring,$matches) )
         {
             return TRUE;
         }
@@ -104,8 +123,8 @@ class WeatherMapDataSource_prometheus extends WeatherMapDataSource {
     
             $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
     
-            $in_query  = 'irate(' . $in_series  . '{ifName="' . $intf . '",instance="' . $instance . '"}[2m])*8';
-            $out_query = 'irate(' . $out_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[2m])*8';
+            $in_query  = 'irate(' . $in_series  . '{ifName="' . $intf . '",instance="' . $instance . '"}[10m])*8';
+            $out_query = 'irate(' . $out_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[10m])*8';
     
             // IN
             $query = urlencode($in_query);
@@ -129,12 +148,50 @@ class WeatherMapDataSource_prometheus extends WeatherMapDataSource {
     
             $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
     
-            $in_query = 'irate(' . $in_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[2m])*8';
+            $in_query = 'irate(' . $in_series . '{ifName="' . $intf . '",instance="' . $instance . '"}[10m])*8';
     
             $query = urlencode($in_query);
             $call = $url . $query;
             $inbw = $this->GetPromData($call);
     
+            $outbw = $inbw;
+        }
+        elseif(preg_match($this->prom_regex_dual_query,$targetstring,$matches))
+        {
+            // In and Out as free Prometheus queries
+            $proto       = $matches[1];
+            $remote_host = $matches[2];
+            $remote_port = $matches[3];
+            $in_query    = $matches[4];
+            $out_query   = $matches[5];
+
+            $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
+
+            // IN
+            $query = urlencode($in_query);
+            $call = $url . $query;
+            $inbw = $this->GetPromData($call);
+
+            // OUT
+            $query = urlencode($out_query);
+            $call = $url . $query;
+            $outbw = $this->GetPromData($call);
+
+        }
+        elseif(preg_match($this->prom_regex_single_query,$targetstring,$matches))
+        {
+            // In and Out as free Prometheus queries
+            $proto       = $matches[1];
+            $remote_host = $matches[2];
+            $remote_port = $matches[3];
+            $in_query    = $matches[4];
+
+            $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
+
+            $query = urlencode($in_query);
+            $call = $url . $query;
+            $inbw = $this->GetPromData($call);
+
             $outbw = $inbw;
         }
     

--- a/WeatherMapDataSource_prometheus_manualtest.php
+++ b/WeatherMapDataSource_prometheus_manualtest.php
@@ -11,21 +11,27 @@
 
 
 //$prom_query = 'prometheus:http:localhost:9090:192.168.178.32:Gi0/13:ifHCInOctets:ifHCOutOctets';
+//$prom_query = 'prometheus:http:localhost:9090:sum(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:sum(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8';
+//$prom_query = 'prometheus:http:localhost:9090:max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:max(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8';
 $prom_query = 'prometheus:http:localhost:9090:192.168.178.32:Gi0/13:ifHCInOctets:ifHCOutOctets';
 
 
 // regexes for single / dual value prom query
 $prom_regex_single_value = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([a-zA-z0-9-_.]+)\:([^:]+)\:([^:]+)$/';
 $prom_regex_dual_value   = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([a-zA-z0-9-_.]+)\:([^:]+)\:([^:]+)\:([^:]+)$/';
+$prom_regex_single_query = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([^:]+)$/';
+$prom_regex_dual_query   = '/^prometheus\:(http|https)\:([a-zA-z0-9-_.]+)\:(\d+)\:([^:]+)\:([^:]+)$/';
 
 
 // Parse the plugin line and recognise prom plugin
 function Recognise($targetstring)
 {
-    global $prom_regex_single_value, $prom_regex_dual_value;
+    global $prom_regex_single_value, $prom_regex_dual_value, $prom_regex_single_query, $prom_regex_dual_query;
 
     if( preg_match($prom_regex_single_value,$targetstring,$matches) ||
-        preg_match($prom_regex_dual_value,$targetstring,$matches) )
+        preg_match($prom_regex_dual_value,$targetstring,$matches) ||
+        preg_match($prom_regex_single_query,$targetstring,$matches) ||
+        preg_match($prom_regex_dual_query,$targetstring,$matches) )
     {
         return TRUE;
     }
@@ -37,7 +43,7 @@ function Recognise($targetstring)
 
 function ReadData($targetstring)
 {
-	global $prom_regex_single_value, $prom_regex_dual_value;
+    global $prom_regex_single_value, $prom_regex_dual_value, $prom_regex_single_query, $prom_regex_dual_query;
 
     $inbw = NULL;
     $outbw = NULL;
@@ -89,6 +95,44 @@ function ReadData($targetstring)
 
         $outbw = $inbw;
 	}
+    elseif(preg_match($prom_regex_dual_query,$targetstring,$matches))
+    {
+        // In and Out as free Prometheus queries
+        $proto       = $matches[1];
+        $remote_host = $matches[2];
+        $remote_port = $matches[3];
+        $in_query    = $matches[4];
+        $out_query   = $matches[5];
+
+        $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
+
+        // IN
+        $query = urlencode($in_query);
+        $call = $url . $query;
+        $inbw = GetPromData($call);
+
+        // OUT
+        $query = urlencode($out_query);
+        $call = $url . $query;
+        $outbw = GetPromData($call);
+
+    }
+    elseif(preg_match($prom_regex_single_query,$targetstring,$matches))
+    {
+        // In and Out as free Prometheus queries
+        $proto       = $matches[1];
+        $remote_host = $matches[2];
+        $remote_port = $matches[3];
+        $in_query    = $matches[4];
+
+        $url = $proto . '://' . $remote_host . ':' . $remote_port . '/api/v1/query?query=';
+
+        $query = urlencode($in_query);
+        $call = $url . $query;
+        $inbw = GetPromData($call);
+
+        $outbw = $inbw;
+    }
 
 	$data_time = time();
     return ( array($inbw,$outbw,$data_time) );

--- a/WeatherMapDataSource_prometheus_manualtest.php
+++ b/WeatherMapDataSource_prometheus_manualtest.php
@@ -11,8 +11,8 @@
 
 
 //$prom_query = 'prometheus:http:localhost:9090:192.168.178.32:Gi0/13:ifHCInOctets:ifHCOutOctets';
-//$prom_query = 'prometheus:http:localhost:9090:sum(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:sum(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8';
-//$prom_query = 'prometheus:http:localhost:9090:max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:max(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8';
+//$prom_query = 'prometheus:http:localhost:9090:sum(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:sum(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8';
+//$prom_query = 'prometheus:http:localhost:9090:max(irate(ifHCInOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8:max(irate(ifHCOutOctets{ifAlias=~".*ae232.*",instance="192.168.178.32"}[10m]))*8';
 $prom_query = 'prometheus:http:localhost:9090:192.168.178.32:Gi0/13:ifHCInOctets:ifHCOutOctets';
 
 


### PR DESCRIPTION
We've been testing Prometheus and when we looked at weathermap integration we found your project.

It worked great for us and we used it with snmp interface metrics collected from Juniper, Extreme and Edgecore (running IPInfusion's OCNOS software) devices.

For what we want to use in production we'd be looking at putting large LAG bundles on our maps and so I added in free-text queries which allow us to use just about anything we have in the metrics as the datasource and works really well for us. In the examples I put in the readme I've showed aggregate traffic and busiest link queries.

We've been running this in the lab for a few weeks now with no issues and we'll be going live with this shortly so I think that this should be good enough to contribute back. 